### PR TITLE
Refactor team types and leaderboard logic

### DIFF
--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -9,7 +9,7 @@ import "../../shared/styles/global.css"
 import "./HomePage.css";
 
 const HomePage: React.FC = () => {
-    const { teams, leaderboard, loading: teamsLoading, error: teamsError } = useFetchTeams();
+    const { teams, loading: teamsLoading, error: teamsError } = useFetchTeams();
     const { events } = useFetchEvents();
     const [filteredEvents, setFilteredEvents] = useState(events);
     const [activeFilter, setActiveFilter] = useState("all");
@@ -82,7 +82,7 @@ const HomePage: React.FC = () => {
                     <h2>Leaderboard</h2>
                     {teamsLoading && <p>Loading leaderboard...</p>}
                 {teamsError && <p style={{ color: "red" }}>{teamsError}</p>}
-                {!teamsLoading && !teamsError && <Leaderboard data={leaderboard} />}
+                {!teamsLoading && !teamsError && <Leaderboard teams={teams} />}
                 </aside>
             </main>
         </>

--- a/frontend/src/pages/Home/components/LeaderBoardList.tsx
+++ b/frontend/src/pages/Home/components/LeaderBoardList.tsx
@@ -1,21 +1,27 @@
 import React from "react";
 import "./LeaderBoard.css";
-
-interface LeaderboardEntry {
-    rank: number;
-    teamName: string;
-    points: number;
-}
+import type { Team } from "../../../shared/types/Team";
 
 interface LeaderboardProps {
-    data: LeaderboardEntry[];
+    teams: Team[];
 }
-
-const Leaderboard: React.FC<LeaderboardProps> = ({ data }) => {
+                    
+const Leaderboard: React.FC<LeaderboardProps> = ({ teams }) => {
+    const leaderboard = [...teams]
+                    .sort((a, b) => b.points - a.points)
+                    .slice(0, 5)
+                    .map((team, index) => ({
+                        rank: index + 1,
+                        teamName: team.description,
+                        points: team.points,
+                    }));
+                    if (leaderboard.length === 0) {
+        return <p>No leaderboard data available.</p>;
+    }
     return (
         <section className="leaderboard">
             <ol className="leaderboard-list">
-                {data.map(entry => (
+                {leaderboard.map(entry => (
                     <li key={entry.rank} className="leaderboard-item">
                         <strong className="rank">#{entry.rank}</strong>
                         <span className="team-name">{entry.teamName}</span>

--- a/frontend/src/pages/Home/components/TeamCard.tsx
+++ b/frontend/src/pages/Home/components/TeamCard.tsx
@@ -1,11 +1,6 @@
 import React from "react";
 import "./TeamList.css";
-
-interface Team {
-    id: string;
-    description: string;
-    imageUrl?: string;
-}
+import type { Team } from "../../../shared/types/Team";
 
 interface TeamCardobj {
     team: Team;

--- a/frontend/src/pages/Home/components/TeamList.tsx
+++ b/frontend/src/pages/Home/components/TeamList.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import TeamCard from "./TeamCard";
 import "./TeamList.css";
-
-interface Team {
-    id: string;
-    description: string;
-    imageUrl?: string;
-}
+import type { Team } from "../../../shared/types/Team";
 
 interface TeamListobj {
     teams: Team[];

--- a/frontend/src/shared/hooks/useFetchTeams.ts
+++ b/frontend/src/shared/hooks/useFetchTeams.ts
@@ -1,9 +1,9 @@
 import { useState, useEffect } from "react";
 import { fetchTeams } from "../../shared/api/teamApi";
+import type { Team } from "../../shared/types/Team";
 
 export const useFetchTeams = () => {
-    const [teams, setTeams] = useState([]);
-    const [leaderboard, setLeaderboard] = useState([]);
+    const [teams, setTeams] = useState<Team[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
@@ -13,15 +13,6 @@ export const useFetchTeams = () => {
                 setLoading(true);
                 const data = await fetchTeams();
                 setTeams(data);
-                const sortedLeaderboard = [...data]
-                    .sort((a, b) => b.points - a.points)
-                    .slice(0, 5)
-                    .map((team, index) => ({
-                        rank: index + 1,
-                        teamName: team.description,
-                        points: team.points,
-                    }));
-                setLeaderboard(sortedLeaderboard);
             } catch (err: any) {
                 setError(err.message || "Failed to fetch teams.");
             } finally {
@@ -32,5 +23,5 @@ export const useFetchTeams = () => {
         loadTeams();
     }, []);
 
-    return { teams, leaderboard, loading, error };
+    return { teams, loading, error };
 };

--- a/frontend/src/shared/types/Team.ts
+++ b/frontend/src/shared/types/Team.ts
@@ -1,0 +1,6 @@
+export interface Team {
+    id: string;
+    description: string;
+    imageUrl?: string;
+    points: number;
+}


### PR DESCRIPTION
Moved the Team interface to a shared types file and updated imports across components. Refactored leaderboard logic to be computed in the LeaderBoardList component instead of the useFetchTeams hook, simplifying the hook's responsibilities.